### PR TITLE
Angular sigmas via ensemble averaging

### DIFF
--- a/configs/1d/defaults.yaml
+++ b/configs/1d/defaults.yaml
@@ -1,197 +1,192 @@
-parameters:
-    amp1:
-        val: 1.
-        active: False
-        lb: 0.
-        ub: 10.
-    amp2:
-        val: 1.
-        active: False
-        lb: 0.
-        ub: 10.
-    amp3:
-        val: 1.
-        active: False
-        lb: 0.
-        ub: 10.
-    lam:
-        val: 526.5
-        active: False
-        lb: 523.
-        ub: 528.
-    Te:
-        val: .5
-        active: False
-        lb: 0.01
-        ub: 3.
-        gradient: 0.0
-    Te_gradient:
-        val: 0.0
-        active: False
-        lb: 0.
-        ub: 10.
-        num_grad_points: 1
-    Ti:
-        val: .2
-        active: False
-        lb: 0.01
-        ub: 3.
-    Z:
-        val: 1.
-        active: False
-        lb: 1.
-        ub: 25.
-    A:
-        val: 40
-        active: False
-    fract:
-        val: 1
-        active: False
-    ne:
-        val: .2
-        active: False
-        lb: .001
-        ub: 10.
-        gradient: 0.0
-    ne_gradient:
-        val: 0.
-        active: False
-        lb: 0.
-        ub: 15.
-        num_grad_points: 1
-    ud:
-        val: 0
-        active: False
-    Va:
-        val: 0
-        active: False
-    m:
-        val: 2.
-        active: False
-        lb: 2.
-        ub: 5.
-    fe:
-        val: []
-        active: False
-        length: 3999
-        type:
-            DLM:
-        lb: -100.
-        ub: -0.5
-        fe_decrease_strict: True
-        symmetric: False
-    blur:
-        val: []
-        active: False
-        lb: 0.
-        ub: 10.
-    specCurvature:
-        val: []
-        active: False
-        lb: .1
-        ub: 10.
-    fitprops:
-        val: []
-        active: False
-
-other:
-    crop_window: 256
-    ion_window_start: 525
-    ion_window_end: 528
-    ele_window_start: 425
-    ele_window_end: 625
-    BinWidth: 10
-    NumBinInRng: 0
-    TotalNumBin: 1023
-    expandedions: False
-    extraoptions:
-        load_ion_spec: False
-        load_ele_spec: True
-        fit_IAW: False
-        fit_EPWb: True
-        fit_EPWr: True
-    PhysParams:
-        background: [0, 0]
-        norm: 0
-    iawoff: 0
-    iawfilter: [1, 4, 24, 528]
-    CCDsize: [1024, 1024]
-    flatbg: 0
-    gain: 1
-    points_per_pixel: 5
-    ang_res_unit: 10
-    lam_res_unit: 5
-    refit: False
-    refit_thresh: 0.25
-    calc_sigmas: False
-
 data:
-    shotnum: 101675
-    shotDay: False
-    launch_data_visualizer: True
-    fit_rng:
-        blue_min: 450
-        blue_max: 510
-        red_min: 545
-        red_max: 650
-        iaw_min: 525
-        iaw_max: 528
-        iaw_cf_min: 526.4
-        iaw_cf_max: 526.6
-    bgscaleE: 1.0
-    bgscaleI: 0.1
-    bgshotmult: 1
-    ion_loss_scale: 1.0
-    ele_t0: 0
-    ion_t0_shift: 0.0
-    ele_lam_shift: 0.0
-    probe_beam: P9
-    dpixel: 3
-    lineouts:
-        type:
-            pixel
-        start: 500
-        end: 510
-        skip: 1
-    background:
-        type:
-            pixel
-        slice: 900
-    probe_beam: P9
-
-plotting:
-    n_sigmas: 3
-    rolling_std_width: 5
-    data_cbar_u: data
-    data_cbar_l: 0
-
-optimizer:
-    # use adam for nn / stochastic gradient descent
-    # use L-BFGS-B for full batch / parameter learning
-    # although adam will work here too
-    method: adam #l-bfgs-b
-    hessian: False
-    y_norm: True
-    x_norm: False
-    grad_method: AD
-    batch_size: 4
-    num_epochs: 2
-    learning_rate: 1.0e-4
-    parameter_norm: True
-    refine_factor: 0
-    num_mins: 8
-    sequential: True
-
-nn:
-    use: false
-    conv_filters: 32|32|16
-    linear_widths: 16|8
-
+  background:
+    slice: 900
+    type: pixel
+  bgscaleE: 1.0
+  bgscaleI: 0.1
+  bgshotmult: 1
+  dpixel: 3
+  ele_lam_shift: 0.0
+  ele_t0: 0
+  fit_rng:
+    blue_max: 510
+    blue_min: 450
+    iaw_cf_max: 526.5
+    iaw_cf_min: 526.5
+    iaw_max: 526.8
+    iaw_min: 526.2
+    red_max: 650
+    red_min: 545
+  ion_loss_scale: 1.0
+  ion_t0_shift: 0.0
+  launch_data_visualizer: true
+  lineouts:
+    end: 510
+    skip: 1
+    start: 500
+    type: pixel
+  probe_beam: P9
+  shotDay: false
+  shotnum: 101675
 dist_fit:
-    window:
-        len: 0.2 #should be even
-        type: hamming # one of [hamming, hann, bartlett]
-
+  window:
+    len: 0.2
+    type: hamming
 mlflow:
-    experiment: inverse-thomson-scattering
-    run: base
+  experiment: inverse-thomson-scattering
+  run: base
+nn:
+  conv_filters: 32|32|16
+  linear_widths: 16|8
+  use: false
+optimizer:
+  batch_size: 4
+  grad_method: AD
+  hessian: true
+  learning_rate: 0.0001
+  method: l-bfgs-b
+  num_epochs: 10
+  num_mins: 8
+  parameter_norm: true
+  refine_factor: 0
+  sequential: true
+  x_norm: false
+  y_norm: true
+other:
+  BinWidth: 10
+  CCDsize:
+  - 1024
+  - 1024
+  NumBinInRng: 0
+  PhysParams:
+    background:
+    - 0
+    - 0
+    norm: 0
+  TotalNumBin: 1023
+  ang_res_unit: 10
+  calc_sigmas: false
+  crop_window: 256
+  ele_window_end: 625
+  ele_window_start: 425
+  expandedions: false
+  extraoptions:
+    fit_EPWb: true
+    fit_EPWr: true
+    fit_IAW: false
+    load_ele_spec: true
+    load_ion_spec: false
+  flatbg: 0
+  gain: 1
+  iawfilter:
+  - 1
+  - 4
+  - 24
+  - 528
+  iawoff: 0
+  ion_window_end: 528
+  ion_window_start: 525
+  lam_res_unit: 5
+  points_per_pixel: 5
+  refit: false
+  refit_thresh: 0.25
+parameters:
+  A:
+    active: false
+    val: 40
+  Te:
+    active: false
+    gradient: 0.0
+    lb: 0.01
+    ub: 3.0
+    val: 0.5
+  Te_gradient:
+    active: false
+    lb: 0.0
+    num_grad_points: 1
+    ub: 10.0
+    val: 0.0
+  Ti:
+    active: false
+    lb: 0.01
+    ub: 3.0
+    val: 0.2
+  Va:
+    active: false
+    val: 0
+  Z:
+    active: false
+    lb: 1.0
+    ub: 25.0
+    val: 1.0
+  amp1:
+    active: false
+    lb: 0.0
+    ub: 10.0
+    val: 1.0
+  amp2:
+    active: false
+    lb: 0.0
+    ub: 10.0
+    val: 1.0
+  amp3:
+    active: false
+    lb: 0.0
+    ub: 10.0
+    val: 1.0
+  blur:
+    active: false
+    lb: 0.0
+    ub: 10.0
+    val: []
+  fe:
+    active: false
+    fe_decrease_strict: true
+    lb: -100.0
+    length: 3999
+    symmetric: false
+    type:
+      DLM: null
+    ub: -0.5
+    val: []
+  fitprops:
+    active: false
+    val: []
+  fract:
+    active: false
+    val: 1
+  lam:
+    active: false
+    lb: 523.0
+    ub: 528.0
+    val: 526.5
+  m:
+    active: false
+    lb: 2.0
+    ub: 5.0
+    val: 2.0
+  ne:
+    active: false
+    gradient: 0.0
+    lb: 0.001
+    ub: 10.0
+    val: 0.2
+  ne_gradient:
+    active: false
+    lb: 0.0
+    num_grad_points: 1
+    ub: 15.0
+    val: 0.0
+  specCurvature:
+    active: false
+    lb: 0.1
+    ub: 10.0
+    val: []
+  ud:
+    active: false
+    val: 0
+plotting:
+  data_cbar_l: 0
+  data_cbar_u: data
+  n_sigmas: 3
+  rolling_std_width: 5

--- a/configs/1d/defaults.yaml
+++ b/configs/1d/defaults.yaml
@@ -175,7 +175,7 @@ optimizer:
     x_norm: False
     grad_method: AD
     batch_size: 4
-    num_epochs: 1
+    num_epochs: 2
     learning_rate: 1.0e-4
     parameter_norm: True
     refine_factor: 0

--- a/configs/1d/inputs.yaml
+++ b/configs/1d/inputs.yaml
@@ -106,7 +106,7 @@ other:
         fit_EPWr: True
     refit: False
     refit_thresh: 5.0
-    calc_sigmas: False
+    calc_sigmas: True
 
 
 mlflow:

--- a/configs/1d/inputs.yaml
+++ b/configs/1d/inputs.yaml
@@ -1,116 +1,109 @@
-parameters:
-    amp1:
-        val: 1.
-        active: True
-        lb: 0.01
-        ub: 3.75
-    amp2:
-        val: 1.
-        active: True
-        lb: 0.01
-        ub: 3.75
-    amp3:
-        val: 1.0
-        active: True
-        lb: 0.01
-        ub: 3.75
-    lam:
-        val: 526.5
-        active: True
-        lb: 523.0
-        ub: 528.0
-    Te:
-        val: .64
-        active: True
-        lb: 0.01
-        ub: 1.5
-    Te_gradient:
-        val: 0.0
-        active: False
-        lb: 0.
-        ub: 10.
-        num_grad_points: 1
-    Ti:
-        val: 0.16
-        active: True
-        lb: 0.001
-        ub: 1.0
-    Z:
-        val: [1., 14.]
-        active: True
-        lb: 0.5
-        ub: 7.0
-    A:
-        val: [1., 40.]
-        active: False
-    fract:
-        val: [.95, .05]
-        active: False
-    ud:
-        val: 0.0
-        active: True
-        lb: -100.0
-        ub: 100.0
-    Va:
-        val: 0.0
-        active: False
-        lb: -20.5
-        ub: 20.5
-    ne:
-        val: 0.23
-        active: True
-        lb: 0.001
-        ub: 1.0
-    ne_gradient:
-        val: 0.
-        active: False
-        lb: 0.
-        ub: 15.
-        num_grad_points: 1
-    m:
-        val: 3
-        active: False
-        lb: 2.0
-        ub: 5.0
-    fe:
-        val: []
-        active: False
-        length: 3999
-        type:
-            DLM:
-        lb: -100.
-        ub: -0.5
-        fe_decrease_strict: False
-        symmetric: False
-
 data:
-    shotnum: 101675
-    lineouts:
-        type:
-            pixel
-        start: 340
-        end: 660
-        skip: 4
-    background:
-        type:
-            Fit
-        slice: 900
-        show: False
-
-other:
-    extraoptions:
-        load_ion_spec: True
-        load_ele_spec: True
-        fit_IAW: False
-        fit_EPWb: True
-        fit_EPWr: True
-    refit: False
-    refit_thresh: 5.0
-    calc_sigmas: True
-
-
-mlflow:
-    experiment: inverse-thomson-scattering
-    run: Ar-H2-05-95-t1000-corrected
-    
+  background:
+    show: false
+    slice: 700
+    type: pixel
+  lineouts:
+    end: 500
+    skip: 4
+    start: 260
+    type: pixel
+  shotnum: 101675
 machine: gpu
+mlflow:
+  experiment: ts-lle
+  run: s109158_IAW_13
+other:
+  calc_sigmas: true
+  extraoptions:
+    fit_EPWb: false
+    fit_EPWr: false
+    fit_IAW: true
+    load_ele_spec: false
+    load_ion_spec: true
+  refit: false
+  refit_thresh: 0.02
+parameters:
+  A:
+    active: false
+    val: 14
+  Te:
+    active: true
+    lb: 0.06
+    ub: 0.12
+    val: 0.08
+  Te_gradient:
+    active: false
+    lb: 0.0
+    num_grad_points: 1
+    ub: 10.0
+    val: 5.0
+  Ti:
+    active: true
+    lb: 0.01
+    ub: 0.1
+    val: 0.05
+  Va:
+    active: true
+    lb: -20.5
+    ub: 20.5
+    val: 0.0
+  Z:
+    active: false
+    lb: 0.5
+    ub: 7.0
+    val: 5
+  amp1:
+    active: false
+    lb: 0.01
+    ub: 3.75
+    val: 1.0
+  amp2:
+    active: false
+    lb: 0.01
+    ub: 3.75
+    val: 1.0
+  amp3:
+    active: true
+    lb: 0.01
+    ub: 3.75
+    val: 1.0
+  fe:
+    active: false
+    fe_decrease_strict: false
+    lb: -100.0
+    length: 3999
+    symmetric: false
+    type:
+      DLM: null
+    ub: -0.5
+    val: []
+  fract:
+    active: false
+    val: 1
+  lam:
+    active: false
+    lb: 523.0
+    ub: 528.0
+    val: 526.5
+  m:
+    active: false
+    lb: 2.0
+    ub: 5.0
+    val: 3.2
+  ne:
+    active: false
+    lb: 0.001
+    ub: 1.0
+    val: 0.06
+  ne_gradient:
+    active: false
+    lb: 0.0
+    num_grad_points: 1
+    ub: 15.0
+    val: 5
+  ud:
+    active: true
+    lb: -100.0
+    ub: 100.0
+    val: 0.0

--- a/configs/arts/defaults.yaml
+++ b/configs/arts/defaults.yaml
@@ -107,7 +107,7 @@ other:
     lam_res_unit: 5
     refit: True
     refit_thresh: 0.25
-    calc_sigmas: False
+    calc_sigmas: True
 
 plotting:
     n_sigmas: 3
@@ -158,11 +158,11 @@ optimizer:
     grad_method: AD
     grad_scalar: 0.5
     batch_size: 5
-    num_epochs: 2
+    num_epochs: 1000
     learning_rate: 1.0e-4
     parameter_norm: True
     refine_factor: 1
-    num_mins: 2
+    ensemble_size: 4
 
 nn:
     use: false

--- a/env.yml
+++ b/env.yml
@@ -4,6 +4,8 @@ channels:
 dependencies:
   - python=3.10
   - pip
+  - pyhdf
+  - xlrd
   - pip:
       - jaxlib
       - jax
@@ -11,8 +13,6 @@ dependencies:
       - numpy
       - scipy
       - matplotlib
-      - pyhdf
-      - xlrd
       - pyyaml
       - mlflow
       - boto3

--- a/inverse_thomson_scattering/fitter.py
+++ b/inverse_thomson_scattering/fitter.py
@@ -65,8 +65,12 @@ def _validate_inputs_(config: Dict) -> Dict:
     """
     if config["other"]["calc_sigmas"]:
         if config["optimizer"]["batch_size"] > 1:
-            print("batch size must be 1 to calculate sigmas")
+            print("batch size must be 1 to calculate sigmas, setting batch_size to 1")
             config["optimizer"]["batch_size"] = 1
+
+    if "spectype" in config["other"]["extraoptions"]:
+        if config["other"]["extraoptions"]["spectype"] == "angular":
+            print("Running Angular, setting batch_size to 1")
 
     # get derived quantities
     config["velocity"] = np.linspace(-7, 7, config["parameters"]["fe"]["length"])
@@ -122,7 +126,7 @@ def scipy_angular_loop(config: Dict, all_data: Dict, sa) -> Tuple[Dict, float, T
     Returns:
 
     """
-    print("Running Angular, setting batch_size to 1")
+
     config["optimizer"]["batch_size"] = 1
     batch = {
         "e_data": all_data["e_data"][config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :],
@@ -311,7 +315,7 @@ def _1d_scipy_loop_(config: Dict, ts_fitter: TSFitter, previous_weights: np.ndar
         method=config["optimizer"]["method"],
         jac=True if config["optimizer"]["grad_method"] == "AD" else False,
         bounds=ts_fitter.bounds,
-        options={"disp": True, "maxiter": 1000},
+        options={"disp": True, "maxiter": config["optimizer"]["num_epochs"]},
     )
 
     best_loss = res["fun"]

--- a/inverse_thomson_scattering/fitter.py
+++ b/inverse_thomson_scattering/fitter.py
@@ -63,6 +63,11 @@ def _validate_inputs_(config: Dict) -> Dict:
     Returns: Dict
 
     """
+    if config["other"]["calc_sigmas"]:
+        if config["optimizer"]["batch_size"] > 1:
+            print("batch size must be 1 to calculate sigmas")
+            config["optimizer"]["batch_size"] = 1
+
     # get derived quantities
     config["velocity"] = np.linspace(-7, 7, config["parameters"]["fe"]["length"])
     if config["parameters"]["fe"]["symmetric"]:

--- a/inverse_thomson_scattering/misc/calibration.py
+++ b/inverse_thomson_scattering/misc/calibration.py
@@ -1,12 +1,24 @@
-# Supplies wavelength, space, time, and throughput calibrations based off of shot numbers including historical values
-# new calibration values should be added here as they are calculated
+from typing import Dict
 import numpy as np
 import scipy.io as sio
-from os.path import join, exists
+from os.path import join
 
 from inverse_thomson_scattering.misc.sa_table import sa_lookup
 
+
 def get_calibrations(shotNum, tstype, CCDsize):
+    """
+    Supplies wavelength, space, time, and throughput calibrations based off of shot numbers including historical values
+    new calibration values should be added here as they are calculated
+
+    Args:
+        shotNum:
+        tstype:
+        CCDsize:
+
+    Returns:
+
+    """
     stddev = dict()
     # Dispersions and calibrations
     if tstype == "angular":
@@ -29,7 +41,7 @@ def get_calibrations(shotNum, tstype, CCDsize):
         stddev["spect_FWHM_ele"] = 0.9  # nominally this is ~.8 or .9 for h2
         stddev["spect_stddev_ele"] = stddev["spect_FWHM_ele"] / 2.3548  # dummy
         stddev["ang_FWHM_ele"] = 1  # see Joe's FDR slides ~1-1.2
-        #IAWtime = 0  # means nothing here just kept to allow one code to be used for both
+        # IAWtime = 0  # means nothing here just kept to allow one code to be used for both
 
     elif tstype == "temporal":
         if shotNum < 105000:
@@ -45,8 +57,8 @@ def get_calibrations(shotNum, tstype, CCDsize):
             magI = 5  # (ps / px) this is just a rough guess
             magE = 5  # (ps / px) this is just a rough guess
 
-        elif shotNum <108950:
-            #these are calibrations for shot 108135
+        elif shotNum < 108950:
+            # these are calibrations for shot 108135
             EPWDisp = 0.4104
             IAWDisp = 0.005749
             EPWoff = 319.3
@@ -57,9 +69,9 @@ def get_calibrations(shotNum, tstype, CCDsize):
             # Sweep speed calculated from 5 Ghz comb (should be updated, date unknown)
             magI = 5  # (ps / px) this is just a rough guess
             magE = 5  # (ps / px) this is just a rough guess
-        
-        elif shotNum <108990:
-            #these are calibrations for shots 108964-
+
+        elif shotNum < 108990:
+            # these are calibrations for shots 108964-
             EPWDisp = 0.4104
             IAWDisp = 0.00959
             EPWoff = 135.0
@@ -84,7 +96,7 @@ def get_calibrations(shotNum, tstype, CCDsize):
             magI = 5  # (ps / px) this is just a rough guess
             magE = 5  # (ps / px) this is just a rough guess
 
-       # IAWtime = 0  # temporal offset between EPW ross and IAW ross (varies shot to shot, can potentially add a fix based off the fiducials)
+    # IAWtime = 0  # temporal offset between EPW ross and IAW ross (varies shot to shot, can potentially add a fix based off the fiducials)
 
     else:
         if shotNum < 104000:
@@ -103,21 +115,21 @@ def get_calibrations(shotNum, tstype, CCDsize):
             IAWtcc = 1024 - 519  # 469;
 
         elif 106303 <= shotNum <= 106321:
-            #refractive teloscope used on 11/8/22
+            # refractive teloscope used on 11/8/22
             EPWDisp = 0.27594
             IAWDisp = 0.00437
-            EPWoff = 388.256  #390.256 worked for 106317
+            EPWoff = 388.256  # 390.256 worked for 106317
             IAWoff = 524.345
 
             stddev["spect_stddev_ion"] = 0.028  # needs to be checked
             stddev["spect_stddev_ele"] = 1.4365  # needs to be checked
 
-            magI = 2.89/.3746 *1.118  # um / px times strech factor accounting for tilt in view
-            magE = 5.13/.36175*1.118  # um / px times strech factor accounting for tilt in view
+            magI = 2.89 / 0.3746 * 1.118  # um / px times strech factor accounting for tilt in view
+            magE = 5.13 / 0.36175 * 1.118  # um / px times strech factor accounting for tilt in view
 
             EPWtcc = 1024 - 503  # 562;
             IAWtcc = 1024 - 578  # 469;
-            
+
         else:
             # needs to be updated with the calibrations from 7-26-22
             EPWDisp = 0.27093
@@ -128,13 +140,13 @@ def get_calibrations(shotNum, tstype, CCDsize):
             stddev["spect_stddev_ion"] = 0.028  # needs to be checked
             stddev["spect_stddev_ele"] = 1.4365  # needs to be checked
 
-            magI = 2.89 *1.079  # um / px times strech factor accounting for tilt in view
-            magE = 5.13 *1.079 # um / px times strech factor accounting for tilt in view
+            magI = 2.89 * 1.079  # um / px times strech factor accounting for tilt in view
+            magE = 5.13 * 1.079  # um / px times strech factor accounting for tilt in view
 
             EPWtcc = 1024 - 516  # 562;
             IAWtcc = 1024 - 450  # 469;
 
-        #IAWtime = 0  # means nothing here just kept to allow one code to be used for both
+        # IAWtime = 0  # means nothing here just kept to allow one code to be used for both
 
     ## Apply calibrations
     axisy = np.arange(1, CCDsize[0] + 1)
@@ -148,7 +160,7 @@ def get_calibrations(shotNum, tstype, CCDsize):
         if tstype == "imaging":
             axisxE = axisxE - EPWtcc * magE
             axisxI = axisxI - IAWtcc * magI
-            #axisxI = axisxI + 200
+            # axisxI = axisxI + 200
     else:
         imp = sio.loadmat(join("files", "angsFRED.mat"), variable_names="angsFRED")
         axisxE = imp["angsFRED"][0, :]
@@ -158,7 +170,15 @@ def get_calibrations(shotNum, tstype, CCDsize):
     return axisxE, axisxI, axisyE, axisyI, magE, stddev
 
 
-def get_scattering_angles(config):
+def get_scattering_angles(config: Dict) -> Dict:
+    """
+    Gets the scattering angles and weights for the given probe beam
+    Args:
+        config:
+
+    Returns:
+
+    """
     if config["other"]["extraoptions"]["spectype"] != "angular":
         sa = sa_lookup(config["data"]["probe_beam"])
     else:

--- a/inverse_thomson_scattering/misc/data_visualizer.py
+++ b/inverse_thomson_scattering/misc/data_visualizer.py
@@ -4,6 +4,17 @@ import tempfile, mlflow, os
 
 
 def launch_data_visualizer(elecData, ionData, all_axes, config):
+    """
+
+    Args:
+        elecData:
+        ionData:
+        all_axes:
+        config:
+
+    Returns:
+
+    """
     if config["data"]["lineouts"]["type"] == "ps" or config["data"]["lineouts"]["type"] == "um":
         LineoutPixelE = [
             np.argmin(abs(all_axes["epw_x"] - loc - config["data"]["ele_t0"]))
@@ -39,41 +50,41 @@ def launch_data_visualizer(elecData, ionData, all_axes, config):
                 vmin=np.amin(ionData),
                 vmax=np.amax(ionData),
             )
-            (sline,) = ax.plot(
+            sline = ax.plot(
                 [all_axes["iaw_x"][LineoutPixelI[0]], all_axes["iaw_x"][LineoutPixelI[0]]],
                 [all_axes["iaw_y"][0], all_axes["iaw_y"][-1]],
                 lw=2,
                 color="w",
             )
-            (eline,) = ax.plot(
+            eline = ax.plot(
                 [all_axes["iaw_x"][LineoutPixelI[-1]], all_axes["iaw_x"][LineoutPixelI[-1]]],
                 [all_axes["iaw_y"][0], all_axes["iaw_y"][-1]],
                 lw=2,
                 color="w",
             )
 
-            (lamsline,) = ax.plot(
+            lamsline = ax.plot(
                 [all_axes["iaw_x"][0], all_axes["iaw_x"][-1]],
                 [config["data"]["fit_rng"]["iaw_min"], config["data"]["fit_rng"]["iaw_min"]],
                 lw=2,
                 color="w",
                 linestyle="--",
             )
-            (lamsline,) = ax.plot(
+            lamsline = ax.plot(
                 [all_axes["iaw_x"][0], all_axes["iaw_x"][-1]],
                 [config["data"]["fit_rng"]["iaw_cf_min"], config["data"]["fit_rng"]["iaw_cf_min"]],
                 lw=2,
                 color="w",
                 linestyle="--",
             )
-            (lamsline,) = ax.plot(
+            lamsline = ax.plot(
                 [all_axes["iaw_x"][0], all_axes["iaw_x"][-1]],
                 [config["data"]["fit_rng"]["iaw_cf_max"], config["data"]["fit_rng"]["iaw_cf_max"]],
                 lw=2,
                 color="w",
                 linestyle="--",
             )
-            (lameline,) = ax.plot(
+            lameline = ax.plot(
                 [all_axes["iaw_x"][0], all_axes["iaw_x"][-1]],
                 [config["data"]["fit_rng"]["iaw_max"], config["data"]["fit_rng"]["iaw_max"]],
                 lw=2,
@@ -96,41 +107,41 @@ def launch_data_visualizer(elecData, ionData, all_axes, config):
                 vmin=np.amin(elecData),
                 vmax=np.amax(elecData),
             )
-            (sline,) = ax.plot(
+            sline = ax.plot(
                 [all_axes["epw_x"][LineoutPixelE[0]], all_axes["epw_x"][LineoutPixelE[0]]],
                 [all_axes["epw_y"][0], all_axes["epw_y"][-1]],
                 lw=2,
                 color="w",
             )
-            (eline,) = ax.plot(
+            eline = ax.plot(
                 [all_axes["epw_x"][LineoutPixelE[-1]], all_axes["epw_x"][LineoutPixelE[-1]]],
                 [all_axes["epw_y"][0], all_axes["epw_y"][-1]],
                 lw=2,
                 color="w",
             )
 
-            (lamsline,) = ax.plot(
+            lamsline = ax.plot(
                 [all_axes["epw_x"][0], all_axes["epw_x"][-1]],
                 [config["data"]["fit_rng"]["blue_min"], config["data"]["fit_rng"]["blue_min"]],
                 lw=2,
                 color="w",
                 linestyle="--",
             )
-            (lameline,) = ax.plot(
+            lameline = ax.plot(
                 [all_axes["epw_x"][0], all_axes["epw_x"][-1]],
                 [config["data"]["fit_rng"]["blue_max"], config["data"]["fit_rng"]["blue_max"]],
                 lw=2,
                 color="w",
                 linestyle="--",
             )
-            (lamsline,) = ax.plot(
+            lamsline = ax.plot(
                 [all_axes["epw_x"][0], all_axes["epw_x"][-1]],
                 [config["data"]["fit_rng"]["red_min"], config["data"]["fit_rng"]["red_min"]],
                 lw=2,
                 color="w",
                 linestyle="--",
             )
-            (lameline,) = ax.plot(
+            lameline = ax.plot(
                 [all_axes["epw_x"][0], all_axes["epw_x"][-1]],
                 [config["data"]["fit_rng"]["red_max"], config["data"]["fit_rng"]["red_max"]],
                 lw=2,

--- a/inverse_thomson_scattering/misc/lineout_plot.py
+++ b/inverse_thomson_scattering/misc/lineout_plot.py
@@ -4,6 +4,23 @@ import os
 
 
 def lineout_plot(sorted_data, sorted_fits, sorted_sqdev, yaxis, s_ind, e_ind, titlestr, filename, td, tag):
+    """
+    This is used to plot the lineouts of the data, fits, and residuals
+    Args:
+        sorted_data:
+        sorted_fits:
+        sorted_sqdev:
+        yaxis:
+        s_ind:
+        e_ind:
+        titlestr:
+        filename:
+        td:
+        tag:
+
+    Returns:
+
+    """
     if len(sorted_data) == 2:
         num_col = 2
     else:

--- a/inverse_thomson_scattering/misc/plotters.py
+++ b/inverse_thomson_scattering/misc/plotters.py
@@ -630,13 +630,7 @@ def ColorPlots(
         C = np.log(C)
 
     im = ax0.imshow(
-        C,
-        cmap,
-        interpolation="none",
-        extent=[x[0], x[-1], y[-1], y[0]],
-        aspect="auto",
-        vmin=vmin,
-        vmax=vmax,
+        C, cmap, interpolation="none", extent=[x[0], x[-1], y[-1], y[0]], aspect="auto", vmin=vmin, vmax=vmax
     )
     ax0.set_title(
         title,

--- a/inverse_thomson_scattering/misc/sa_table.py
+++ b/inverse_thomson_scattering/misc/sa_table.py
@@ -1,6 +1,16 @@
 import numpy as np
 
-def sa_lookup(beam):
+
+def sa_lookup(beam) -> dict:
+    """
+    Gets the scattering angles and weights for the given probe beam
+
+    Args:
+        beam:
+
+    Returns:
+
+    """
     if beam == "P9":
         # Scattering angle in degrees for OMEGA TIM6 TS
         sa = dict(
@@ -154,6 +164,6 @@ def sa_lookup(beam):
             ),
         )
     else:
-        raise NotImplmentedError("Other probe geometrries are not yet supported")
-    
+        raise NotImplementedError("Other probe geometrries are not yet supported")
+
     return sa

--- a/inverse_thomson_scattering/misc/utils.py
+++ b/inverse_thomson_scattering/misc/utils.py
@@ -1,9 +1,9 @@
-import os, mlflow, flatten_dict, boto3, yaml, botocore, shutil, time, tempfile
+import os, mlflow, flatten_dict, boto3, botocore, shutil, time, tempfile
 from urllib.parse import urlparse
 
 
 def log_params(cfg):
-    flattened_dict = flatten_dict.flatten(cfg, reducer="dot")  # dict(flatdict.FlatDict(cfg, delimiter="."))
+    flattened_dict = flatten_dict.flatten(cfg, reducer="dot")
     num_entries = len(flattened_dict.keys())
 
     if num_entries > 100:

--- a/inverse_thomson_scattering/model/TSFitter.py
+++ b/inverse_thomson_scattering/model/TSFitter.py
@@ -22,6 +22,7 @@ class TSFitter:
             dummy_batch: Dictionary of dummy data
 
     """
+
     def __init__(self, cfg: Dict, sas, dummy_batch):
         """
 
@@ -224,6 +225,21 @@ class TSFitter:
         return loss, sqdev, used_points, [ThryE, ThryI, params]
 
     def calc_ei_error(self, batch, ThryI, lamAxisI, ThryE, lamAxisE, denom, reduce_func=jnp.mean):
+        """
+        This function calculates the error in the fit of the IAW and EPW
+
+        Args:
+            batch:
+            ThryI:
+            lamAxisI:
+            ThryE:
+            lamAxisE:
+            denom:
+            reduce_func:
+
+        Returns:
+
+        """
         i_error = 0.0
         e_error = 0.0
         i_data = batch["i_data"]
@@ -318,7 +334,17 @@ class TSFitter:
 
         return i_error + e_error
 
-    def __loss__(self, weights, batch):
+    def __loss__(self, weights, batch: Dict):
+        """
+        This function calculates the value of the loss function
+
+        Args:
+            weights:
+            batch:
+
+        Returns:
+
+        """
         params = self.weights_to_params(weights)
         ThryE, ThryI, lamAxisE, lamAxisI = self.spec_calc(params, batch)
         i_error, e_error = self.calc_ei_error(
@@ -339,7 +365,7 @@ class TSFitter:
         total_loss = ion_error + e_error + density_loss + temperature_loss + momentum_loss
         return total_loss, [ThryE, normed_e_data, params]
 
-    def _get_normed_batch_(self, batch):
+    def _get_normed_batch_(self, batch: Dict):
         """
         Normalizes the batch
 
@@ -354,7 +380,17 @@ class TSFitter:
         normed_batch["e_data"] = normed_batch["e_data"] / self.e_input_norm
         return normed_batch
 
-    def loss(self, weights, batch):
+    def loss(self, weights, batch: Dict):
+        """
+        High level function that returns the value of the loss function
+
+        Args:
+            weights:
+            batch: Dict
+
+        Returns:
+
+        """
         if self.cfg["optimizer"]["method"] == "l-bfgs-b":
             pytree_weights = self.unravel_pytree(weights)
             value, _ = self._loss_(pytree_weights, batch)

--- a/inverse_thomson_scattering/model/physics/form_factor.py
+++ b/inverse_thomson_scattering/model/physics/form_factor.py
@@ -38,6 +38,14 @@ def zprimeMaxw(xi):
 
 
 class FormFactor:
+    """
+    This class calculates the form factor for a given set of plasma conditions and scattering angles.
+
+    Args:
+        lamrang:
+        npts:
+    """
+
     def __init__(self, lamrang, npts):
         # basic quantities
         self.C = 2.99792458e10
@@ -138,12 +146,8 @@ class FormFactor:
         num_species = len(fract)
         num_ion_pts = jnp.shape(xii)
         chiI = jnp.zeros(num_ion_pts)
-        ZpiR = jnp.interp(
-            xii, self.xi2, self.Zpi[0, :], left=xii**-2, right=xii**-2
-        )
-        ZpiI = jnp.interp(
-            xii, self.xi2, self.Zpi[1, :], left=0, right=0
-        )
+        ZpiR = jnp.interp(xii, self.xi2, self.Zpi[0, :], left=xii**-2, right=xii**-2)
+        ZpiI = jnp.interp(xii, self.xi2, self.Zpi[1, :], left=0, right=0)
         chiI = jnp.sum(-0.5 / (kldi**2) * (ZpiR + jnp.sqrt(-1 + 0j) * ZpiI), 3)
 
         # electron susceptibility
@@ -184,9 +188,7 @@ class FormFactor:
 
         chiEI = jnp.pi / (klde**2) * jnp.sqrt(-1 + 0j) * df
 
-        ratmod = jnp.exp(
-            jnp.interp(self.xi1, x, jnp.log(jnp.squeeze(DF)))
-        )
+        ratmod = jnp.exp(jnp.interp(self.xi1, x, jnp.log(jnp.squeeze(DF))))
         ratdf = jnp.gradient(ratmod, self.xi1[1] - self.xi1[0])
 
         def this_ratintn(this_dx):
@@ -198,10 +200,10 @@ class FormFactor:
         # else:
         #     chiERrat = jnp.interpn(jnp.arange(0, 2 * jnp.pi, 10**-1.2018), xi2, chiERratprim, beta, xie, "spline")
         chiERrat = -1.0 / (klde**2) * chiERrat
-        
+
         chiE = chiERrat + chiEI
         epsilon = 1.0 + chiE + chiI
-        
+
         # This line needs to be changed if ion distribution is changed!!!
         ion_comp_fact = jnp.transpose(fract * Z**2 / Zbar / vTi, [1, 0, 2, 3])
         ion_comp = ion_comp_fact * (
@@ -210,9 +212,8 @@ class FormFactor:
 
         ele_comp = (jnp.abs(1.0 + chiI)) ** 2.0 * fe_vphi / vTe
         # ele_compE = fe_vphi / vTe # commented because unused
-        
+
         SKW_ion_omg = 1.0 / k[..., jnp.newaxis] * ion_comp / ((jnp.abs(epsilon[..., jnp.newaxis])) ** 2)
-        
 
         SKW_ion_omg = jnp.sum(SKW_ion_omg, 3)
         SKW_ele_omg = 1.0 / k * (ele_comp) / ((jnp.abs(epsilon)) ** 2)
@@ -226,5 +227,4 @@ class FormFactor:
         formfactor = PsLam
         # formfactorE = PsLamE # commented because unused
 
-        
         return formfactor, lams

--- a/inverse_thomson_scattering/process/lineouts.py
+++ b/inverse_thomson_scattering/process/lineouts.py
@@ -9,6 +9,10 @@ from inverse_thomson_scattering.process.evaluate_background import get_lineout_b
 def get_lineouts(
     elecData, ionData, BGele, BGion, axisxE, axisxI, axisyE, axisyI, shift_zero, IAWtime, xlab, sa, config
 ) -> Dict:
+    """
+    This function extracts the lineouts from the data and finds the background signal
+
+    """
     # Convert lineout locations to pixel
     if config["data"]["lineouts"]["type"] == "ps" or config["data"]["lineouts"]["type"] == "um":
         LineoutPixelE = [np.argmin(abs(axisxE - loc - shift_zero)) for loc in config["data"]["lineouts"]["val"]]

--- a/inverse_thomson_scattering/process/postprocess.py
+++ b/inverse_thomson_scattering/process/postprocess.py
@@ -78,7 +78,7 @@ def recalculate_with_chosen_weights(
             active_params = ts_fitter.weights_to_params(fitted_weights, return_static_params=False)
             hess = ts_fitter.h_loss_wrt_params(active_params, batch)
             sigmas = get_sigmas(all_params.keys(), hess, config["optimizer"]["batch_size"])
-            print(f"Number of 0s in sigma: {len(np.where(sigmas==0)[0])}")
+            # print(f"Number of 0s in sigma: {len(np.where(sigmas==0)[0])}")
 
     else:
         for i_batch, inds in enumerate(batch_indices):
@@ -158,7 +158,6 @@ def get_sigmas(keys: List, hess: Dict, batch_size: int) -> Dict:
             inv_slice = inv[k1, k1]
             temp = np.sign(inv_slice) * np.sqrt(np.abs(inv_slice))
             sigmas[i, k1] = temp
-            print(sigmas[i, k1])
 
     return sigmas
 

--- a/inverse_thomson_scattering/process/postprocess.py
+++ b/inverse_thomson_scattering/process/postprocess.py
@@ -183,11 +183,11 @@ def postprocess(config, batch_indices, all_data: Dict, all_axes: Dict, ts_fitter
 
     mlflow.log_metrics({"refitting time": round(time.time() - t1, 2)})
 
-    final_params = _sigmas_and_plots_(config, fitted_weights, batch_indices, all_data, ts_fitter, all_axes)
+    final_params, sigmas = _sigmas_and_plots_(config, fitted_weights, batch_indices, all_data, ts_fitter, all_axes)
 
     mlflow.set_tag("status", "done plotting")
 
-    return final_params
+    return final_params, sigmas
 
 
 def _get_refitted_1d_weights(config, batch_indices, all_data, ts_fitter, fitted_weights):
@@ -291,4 +291,4 @@ def _sigmas_and_plots_(config, fitted_weights, batch_indices, all_data, ts_fitte
             mlflow.log_metrics({"plotting time": round(time.time() - t1, 2)})
         mlflow.log_artifacts(td)
 
-    return final_params
+    return final_params, sigmas

--- a/inverse_thomson_scattering/process/postprocess.py
+++ b/inverse_thomson_scattering/process/postprocess.py
@@ -72,7 +72,6 @@ def recalculate_with_chosen_weights(
         sqdevs["ele"] = sqds["ele"]
 
         for k in all_params.keys():
-            # all_params[k] = np.concatenate([all_params[k], params[k].reshape(-1)])
             all_params[k] = params[k].reshape(-1)
 
         if calc_sigma:
@@ -162,64 +161,98 @@ def get_sigmas(keys: List, hess: Dict, batch_size: int) -> Dict:
     return sigmas
 
 
-def postprocess(config, batch_indices, all_data: Dict, all_axes: Dict, ts_fitter, sa, fitted_weights):
+def postprocess(config, batch_indices, all_data: Dict, all_axes: Dict, ts_fitter, fitted_weights):
+    """
+    This is where
+    - plots are made
+    - data are stored to disk
+    - weights are stored to disk
+    - sigmas are calculated from fitted weights
+
+    Args:
+        config:
+        batch_indices:
+        all_data:
+        all_axes:
+        ts_fitter:
+        sa:
+        fitted_weights:
+
+    Returns:
+
+    """
     t1 = time.time()
 
     if config["other"]["extraoptions"]["spectype"] != "angular_full" and config["other"]["refit"]:
-        losses_init, sqdevs, used_points, fits, sigmas, all_params = recalculate_with_chosen_weights(
-            config, batch_indices, all_data, ts_fitter, False, fitted_weights
-        )
-
-        # refit bad fits
-        red_losses_init = losses_init / (1.1 * (used_points - len(all_params)))
-        true_batch_size = config["optimizer"]["batch_size"]
-        config["optimizer"]["batch_size"] = 1
-        mlflow.log_metrics({"number of fits": len(batch_indices.flatten())})
-        mlflow.log_metrics({"number of refits": int(np.sum(red_losses_init > config["other"]["refit_thresh"]))})
-
-        for i in batch_indices.flatten()[red_losses_init > config["other"]["refit_thresh"]]:
-            if i == 0:
-                continue
-
-            batch = {
-                "e_data": np.reshape(all_data["e_data"][i], (1, -1)),
-                "e_amps": np.reshape(all_data["e_amps"][i], (1, -1)),
-                "i_data": np.reshape(all_data["i_data"][i], (1, -1)),
-                "i_amps": np.reshape(all_data["i_amps"][i], (1, -1)),
-                "noise_e": np.reshape(config["other"]["PhysParams"]["noiseE"][i], (1, -1)),
-                "noise_i": np.reshape(config["other"]["PhysParams"]["noiseI"][i], (1, -1)),
-            }
-
-            ts_fitter_refit = TSFitter(config, sa, batch)
-            new_weights = np.zeros(ts_fitter_refit["init_weights"].shape)
-
-            for ii, key in enumerate(fitted_weights[i // true_batch_size].keys()):
-                new_weights[ii] = fitted_weights[(i - 1) // true_batch_size][key][(i - 1) % true_batch_size][0]
-
-            ts_fitter_refit["init_weights"] = new_weights
-
-            res = spopt.minimize(
-                ts_fitter_refit.vg_loss if config["optimizer"]["grad_method"] == "AD" else ts_fitter_refit.loss,
-                ts_fitter_refit.flattened_weights,
-                args=batch,
-                method=config["optimizer"]["method"],
-                jac=True if config["optimizer"]["grad_method"] == "AD" else False,
-                # hess=hess_fn if config["optimizer"]["hessian"] else None,
-                bounds=ts_fitter_refit["bounds"],
-                options={"disp": True},
-            )
-            cur_result = ts_fitter_refit["unravel_pytree"](res["x"])
-
-            for key in fitted_weights[i // true_batch_size].keys():
-                cur_value = cur_result[key][0, 0]
-                new_vals = fitted_weights[i // true_batch_size][key]
-                new_vals = new_vals.at[tuple([i % true_batch_size, 0])].set(cur_value)
-                fitted_weights[i // true_batch_size][key] = new_vals
-
-        config["optimizer"]["batch_size"] = true_batch_size
+        fitted_weights = _get_refitted_1d_weights(config, batch_indices, all_data, ts_fitter, fitted_weights)
 
     mlflow.log_metrics({"refitting time": round(time.time() - t1, 2)})
 
+    final_params = _plots_(config, fitted_weights, batch_indices, all_data, ts_fitter, all_axes)
+    mlflow.log_metrics({"plotting time": round(time.time() - t1, 2)})
+
+    mlflow.set_tag("status", "done plotting")
+
+    return final_params
+
+
+def _get_refitted_1d_weights(config, batch_indices, all_data, ts_fitter, fitted_weights):
+    losses_init, sqdevs, used_points, fits, sigmas, all_params = recalculate_with_chosen_weights(
+        config, batch_indices, all_data, ts_fitter, False, fitted_weights
+    )
+
+    # refit bad fits
+    red_losses_init = losses_init / (1.1 * (used_points - len(all_params)))
+    true_batch_size = config["optimizer"]["batch_size"]
+    config["optimizer"]["batch_size"] = 1
+    mlflow.log_metrics({"number of fits": len(batch_indices.flatten())})
+    mlflow.log_metrics({"number of refits": int(np.sum(red_losses_init > config["other"]["refit_thresh"]))})
+
+    for i in batch_indices.flatten()[red_losses_init > config["other"]["refit_thresh"]]:
+        if i == 0:
+            continue
+
+        batch = {
+            "e_data": np.reshape(all_data["e_data"][i], (1, -1)),
+            "e_amps": np.reshape(all_data["e_amps"][i], (1, -1)),
+            "i_data": np.reshape(all_data["i_data"][i], (1, -1)),
+            "i_amps": np.reshape(all_data["i_amps"][i], (1, -1)),
+            "noise_e": np.reshape(config["other"]["PhysParams"]["noiseE"][i], (1, -1)),
+            "noise_i": np.reshape(config["other"]["PhysParams"]["noiseI"][i], (1, -1)),
+        }
+
+        ts_fitter_refit = TSFitter(config, sa, batch)
+        new_weights = np.zeros(ts_fitter_refit["init_weights"].shape)
+
+        for ii, key in enumerate(fitted_weights[i // true_batch_size].keys()):
+            new_weights[ii] = fitted_weights[(i - 1) // true_batch_size][key][(i - 1) % true_batch_size][0]
+
+        ts_fitter_refit["init_weights"] = new_weights
+
+        res = spopt.minimize(
+            ts_fitter_refit.vg_loss if config["optimizer"]["grad_method"] == "AD" else ts_fitter_refit.loss,
+            ts_fitter_refit.flattened_weights,
+            args=batch,
+            method=config["optimizer"]["method"],
+            jac=True if config["optimizer"]["grad_method"] == "AD" else False,
+            # hess=hess_fn if config["optimizer"]["hessian"] else None,
+            bounds=ts_fitter_refit["bounds"],
+            options={"disp": True},
+        )
+        cur_result = ts_fitter_refit["unravel_pytree"](res["x"])
+
+        for key in fitted_weights[i // true_batch_size].keys():
+            cur_value = cur_result[key][0, 0]
+            new_vals = fitted_weights[i // true_batch_size][key]
+            new_vals = new_vals.at[tuple([i % true_batch_size, 0])].set(cur_value)
+            fitted_weights[i // true_batch_size][key] = new_vals
+
+    config["optimizer"]["batch_size"] = true_batch_size
+
+    return fitted_weights
+
+
+def _plots_(config, fitted_weights, batch_indices, all_data, ts_fitter, all_axes):
     with tempfile.TemporaryDirectory() as td:
         os.makedirs(os.path.join(td, "plots"), exist_ok=True)
         os.makedirs(os.path.join(td, "binary"), exist_ok=True)
@@ -228,8 +261,8 @@ def postprocess(config, batch_indices, all_data: Dict, all_axes: Dict, ts_fitter
             best_weights_val = {}
             best_weights_std = {}
             for k, v in fitted_weights.items():
-                best_weights_val[k] = np.average(v, axis=0)#[0, :]
-                best_weights_std[k] = np.std(v, axis=0)#[0, :]
+                best_weights_val[k] = np.average(v, axis=0)  # [0, :]
+                best_weights_std[k] = np.std(v, axis=0)  # [0, :]
             losses, sqdevs, used_points, fits, sigmas, all_params = recalculate_with_chosen_weights(
                 config, batch_indices, all_data, ts_fitter, config["other"]["calc_sigmas"], best_weights_val
             )
@@ -261,8 +294,5 @@ def postprocess(config, batch_indices, all_data: Dict, all_axes: Dict, ts_fitter
                 config, losses, all_params, used_points, all_axes, fits, all_data, sqdevs, sigmas, td
             )
         mlflow.log_artifacts(td)
-    mlflow.log_metrics({"plotting time": round(time.time() - t1, 2)})
-
-    mlflow.set_tag("status", "done plotting")
 
     return final_params

--- a/inverse_thomson_scattering/runner.py
+++ b/inverse_thomson_scattering/runner.py
@@ -76,6 +76,9 @@ def run(cfg_path: str, mode: str) -> str:
     with mlflow.start_run(run_id=run_id) as mlflow_run:
         _run_(config, mode=mode)
 
+    if "MLFLOW_EXPORT" in os.environ:
+        utils.export_run(run_id)
+
     return run_id
 
 

--- a/inverse_thomson_scattering/runner.py
+++ b/inverse_thomson_scattering/runner.py
@@ -98,7 +98,7 @@ def _run_(config: Dict, mode: str = "fit"):
     utils.log_params(config)
     t0 = time.time()
     if mode == "fit":
-        fit_results, loss = fitter.fit(config=config)
+        fit_results, sigmas, loss = fitter.fit(config=config)
     elif mode == "forward":
         calc_spec(config=config)
     metrics_dict = {"total_time": time.time() - t0, "num_cores": int(mp.cpu_count())}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ mlflow
 mlflow_export_import
 boto3
 flatten-dict
-flatdict
 optax
 tqdm
 jaxopt

--- a/run_tsadar.py
+++ b/run_tsadar.py
@@ -3,10 +3,9 @@ import argparse, os
 from jax import config
 
 config.update("jax_enable_x64", True)
-#config.update("jax_disable_jit", True)
+# config.update("jax_disable_jit", True)
 
 from inverse_thomson_scattering.runner import run, run_job
-from inverse_thomson_scattering.misc.utils import export_run
 
 
 if __name__ == "__main__":
@@ -22,6 +21,3 @@ if __name__ == "__main__":
         run_id = args.run_id
     else:
         run_id = run(args.cfg, mode=args.mode)
-
-    if "MLFLOW_EXPORT" in os.environ:
-        export_run(run_id)

--- a/tests/configs/time_test_defaults.yaml
+++ b/tests/configs/time_test_defaults.yaml
@@ -170,8 +170,8 @@ optimizer:
     x_norm: False
     grad_method: AD
     batch_size: 2
-    num_epochs: 200
-    learning_rate: 1.0e-4
+    num_epochs: 1000
+    learning_rate: 1.0e-2
     parameter_norm: True
     refine_factor: 0
     num_mins: 1


### PR DESCRIPTION
This PR
- enables angular sigmas via ensemble averaging. This is very slow because the forward pass recompiles every single ensemble run. This can be alleviated by running the forward pass in parallel over multiple GPUs as well as by removing the need to recompile every iteration. This will be a new issue
- enables non-distribution sigmas. This had broken somehow. In fixing it, I realized that if we calculate the hessian over a batch of larger than 1, the parameters are all related as are their sigmas. In order to remove that interdependency, I made it so that the batch size has to be 1. We should discuss whether that is okay and/or desirable. There is also a test now that verifies the sigmas are > 0.

YAMLs are also reformatted by the newest version of `black`. 